### PR TITLE
Accept empty values for parameters in POST action

### DIFF
--- a/json-templates/apigw-params-form.txt
+++ b/json-templates/apigw-params-form.txt
@@ -6,10 +6,10 @@
   }, 
   "v": "2",
   "post": {  
-      #foreach($param in $input.path('$').split('&'))
-        #set ($kv = $param.split('='))
-        "$util.urlDecode($kv[0])": "$util.escapeJavaScript($util.urlDecode($kv[1]))" #if($foreach.hasNext), #end 
-      #end 
+    #foreach($param in $input.path('$').split('&'))
+      #set ($kv = $param.split('='))
+      "$util.urlDecode($kv[0])": #if($kv.size() > 1)"$util.escapeJavaScript($util.urlDecode($kv[1]))"#{else}null#end#if($foreach.hasNext),#end
+    #end
   },
   "headers": { 
     #foreach($param in $input.params().header.entrySet()) 


### PR DESCRIPTION
I made a small change in my forked version to accept empty values.
The current configuration will break if I pass for example: `"command=/weather&text="`