### PR TITLE
Implement support for request bodies with content-type: text/xml

### DIFF
--- a/json-templates/apigw-params-textxml.txt
+++ b/json-templates/apigw-params-textxml.txt
@@ -1,0 +1,29 @@
+{ 
+  "context": { 
+    "method": "$context.httpMethod", 
+    "path": "$context.resourcePath", 
+    "sourceIp":"$context.identity.sourceIp"
+  }, 
+  "body" : $input.json('$'), 
+  "v": "2",
+  "headers": { 
+    #foreach($param in $input.params().header.entrySet()) 
+      "$param.getKey()": "$util.escapeJavaScript($param.getValue())" #if($foreach.hasNext),#end 
+    #end 
+  }, 
+  "queryString": { 
+    #foreach($param in $input.params().querystring.entrySet()) 
+      "$param.getKey()": "$util.escapeJavaScript($param.getValue())" #if($foreach.hasNext),#end 
+    #end 
+  }, 
+  "env": { 
+    #foreach($param in $stageVariables.entrySet()) 
+      "$param.getKey()": "$util.escapeJavaScript($param.getValue())" #if($foreach.hasNext),#end 
+    #end 
+  }, 
+  "pathParams": { 
+    #foreach($param in $input.params().path.entrySet()) 
+      "$param.getKey()": "$util.escapeJavaScript($param.getValue())" #if($foreach.hasNext),#end 
+    #end 
+  }
+}

--- a/spec/rebuild-web-api-spec.js
+++ b/spec/rebuild-web-api-spec.js
@@ -147,8 +147,22 @@ describe('rebuildWebApi', function () {
 					expect(params.post).toEqual({name: 'tom', title: 'mr', surname: ''});
 				}).then(done, done.fail);
 			});
-
+			it('captures text/xml request bodies', function (done) {
+				underTest(newObjects.lambdaFunction, 'original', apiId, {version: 2, routes: {'echo': { 'POST': {}}}}, awsRegion)
+				.then(function () {
+					var xml = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<test>1234</test>';
+					return invoke('original/echo', {
+						headers: {'Content-Type': 'text/xml'},
+						body: xml,
+						method: 'POST'
+					});
+				}).then(function (contents) {
+					var params = JSON.parse(contents.body);
+					expect(params.body).toEqual('<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<test>1234</test>');
+				}).then(done, done.fail);
+			});
 		});
+
 		it('creates multiple methods for the same resource', function (done) {
 			underTest(newObjects.lambdaFunction, 'original', apiId, {version: 2, routes: {echo: { GET: {}, POST: {}, PUT: {}}}}, awsRegion)
 			.then(function () {

--- a/src/tasks/rebuild-web-api.js
+++ b/src/tasks/rebuild-web-api.js
@@ -16,6 +16,7 @@ module.exports = function rebuildWebApi(functionName, functionVersion, restApiId
 		knownIds = {},
 		inputTemplateJson,
 		inputTemplateForm,
+		inputTemplateTextXml,
 		getOwnerId = function () {
 			return iam.getUserAsync().then(function (result) {
 				ownerId = result.User.Arn.split(':')[4];
@@ -142,7 +143,8 @@ module.exports = function rebuildWebApi(functionName, functionVersion, restApiId
 					integrationHttpMethod: 'POST',
 					requestTemplates: {
 						'application/json': inputTemplateJson,
-						'application/x-www-form-urlencoded': inputTemplateForm
+						'application/x-www-form-urlencoded': inputTemplateForm,
+						'text/xml': inputTemplateTextXml
 					},
 					uri: 'arn:aws:apigateway:' + awsRegion + ':lambda:path/2015-03-31/functions/arn:aws:lambda:' + awsRegion + ':' + ownerId + ':function:' + functionName + ':${stageVariables.lambdaVersion}/invocations'
 				});
@@ -280,6 +282,10 @@ module.exports = function rebuildWebApi(functionName, functionVersion, restApiId
 				return fs.readFileAsync(templateFile('apigw-params-form.txt'), 'utf8');
 			}).then(function (inputTemplate) {
 				inputTemplateForm = inputTemplate;
+			}).then(function () {
+				return fs.readFileAsync(templateFile('apigw-params-textxml.txt'), 'utf8');
+			}).then(function (inputTemplate) {
+				inputTemplateTextXml = inputTemplate;
 			});
 		},
 		pathSort = function (resA, resB) {
@@ -332,5 +338,3 @@ module.exports = function rebuildWebApi(functionName, functionVersion, restApiId
 		.then(rebuildApi)
 		.then(deployApi);
 };
-
-


### PR DESCRIPTION
Previously, POST requests to AWS API Gateway with content-type: text/xml were not being sent to Lambda correctly because they lacked mapping templates, which were only defined for application/json and application/x-form-www-urlencoded. This caused an error to be returned for all POSTs with content-type: text/xml.

This PR adds a mapping template for text/xml requests, which behaves similarly to the current application/json template but maps the XML POST body to the “body” property as a string.