### PR TITLE
Should set the engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test": "node spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
+  "engines" : { 
+  	"node" : "~0.10.36" 
+  },
   "dependencies": {
     "archiver": "^0.21.0",
     "aws-sdk": "^2.2.33",


### PR DESCRIPTION
Since the AWS runs Node on an old version of Node it might be good to state that explicitly. 