### PR TITLE
Api config error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 SpecRunner.html
 .grunt
 *.log
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test": "node spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
+  "engines" : { 
+  	"node" : "~0.10.36" 
+  },
   "dependencies": {
     "archiver": "^0.21.0",
     "aws-sdk": "^2.2.33",

--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -289,8 +289,14 @@ describe('create', function () {
 		beforeEach(function () {
 			config.handler = undefined;
 			config['api-module'] = 'main';
+		});		
+		it('fails if no APIConfig is found on the module', function(done) {
+			createFromDir('api-gw-no-export').then(done.fail, function (error) {
+				console.log(error);
+				expect(error).toEqual('No apiConfig defined on module \'main\'. Are you missing an module.exports?');
+				done();
+			});
 		});
-
 		it('ignores the handler but creates an API if the api-module is provided', function (done) {
 			createFromDir('api-gw-hello-world').then(function (creationResult) {
 				var apiId = creationResult.api && creationResult.api.id;

--- a/spec/test-projects/api-gw-no-export/main.js
+++ b/spec/test-projects/api-gw-no-export/main.js
@@ -1,0 +1,11 @@
+/*global exports, console*/
+var apiConfig = function () {
+	'use strict';
+	return {
+		version: 2,
+		routes: { hello: { 'GET' : {} }}
+	};
+};
+
+// No module.exports.apiConfig in this example
+// module.exports.apiConfig = apiConfig;

--- a/spec/test-projects/api-gw-no-export/package.json
+++ b/spec/test-projects/api-gw-no-export/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "api-gw-no-export",
+  "private": true,
+  "files": ["main.js"]
+}

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -73,8 +73,11 @@ module.exports = function create(options) {
 		},
 		createWebApi = function (lambdaMetadata) {
 			var apiModule = require(path.join(options.source, options['api-module'])),
-				apiConfig = apiModule.apiConfig(),
 				apiGateway = Promise.promisifyAll(new aws.APIGateway({region: options.region}));
+			if(!apiModule.apiConfig){
+				return Promise.reject('No apiConfig defined on module \'' + options['api-module'] + '\'. Are you missing an module.exports?');
+			};			
+			var apiConfig = apiModule.apiConfig();
 			return apiGateway.createRestApiAsync({
 				name: options.name
 			}).then(function (result) {


### PR DESCRIPTION
If you forget to `module.exports` your api you get a very cryptic error message. 

`[TypeError: Object #<Object> has no method 'apiConfig']`

I've tried to improve on this error message with this PR. 

It's a stupid mistake but had me looking for an hour before @gojko helped me see clearly. Maybe now not everyone needs to call him ^^