### PR TITLE
Fix failing tmp path tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "test": "node spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
-  "engines" : { 
-  	"node" : "~0.10.36" 
-  },
   "dependencies": {
     "archiver": "^0.21.0",
     "aws-sdk": "^2.2.33",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test": "node spec/support/jasmine-runner.js"
   },
   "author": "Gojko Adzic <gojko@gojko.com> http://gojko.net",
+  "engines" : { 
+  	"node" : "~0.10.36" 
+  },
   "dependencies": {
     "archiver": "^0.21.0",
     "aws-sdk": "^2.2.33",

--- a/spec/helpers/tmpdir.js
+++ b/spec/helpers/tmpdir.js
@@ -1,0 +1,6 @@
+/*global require */
+var os = require('os')
+module.exports.tmpdir = function() {
+	var t = os.tmpdir();
+	return t.substr(-1) === '/' ? t.substr(0, t.length - 1) : t;
+};

--- a/spec/tmppath-spec.js
+++ b/spec/tmppath-spec.js
@@ -1,7 +1,7 @@
 /*global describe, it, expect, require */
 var underTest = require ('../src/util/tmppath'),
 	path = require('path'),
-	os = require('os'),
+	os = require('./helpers/tmpdir.js'),
 	fs = require('fs');
 describe('tmppath', function () {
 	'use strict';

--- a/spec/zipdir-spec.js
+++ b/spec/zipdir-spec.js
@@ -3,7 +3,7 @@ var tmppath = require('../src/util/tmppath'),
 	shell = require('shelljs'),
 	fs = require('fs'),
 	path = require('path'),
-	os = require('os'),
+	os = require('./helpers/tmpdir.js'),
 	underTest = require('../src/tasks/zipdir');
 describe('zipdir', function () {
 	'use strict';


### PR DESCRIPTION
The `os.tmpdir()’ has a trailing slash in the end, on OSX. This fix should normalize this over differnt os's. 
