### PR TITLE
Added an os-agnostic way of getting tmp dir name

### DIFF
--- a/spec/helpers/tmpdir.js
+++ b/spec/helpers/tmpdir.js
@@ -1,6 +1,7 @@
-/*global require */
-var os = require('os')
-module.exports.normalize = function() {
+/*global module, require */
+var os = require('os');
+module.exports.normalize = function () {
+	'use strict';
 	var t = os.tmpdir();
 	return t.substr(-1) === '/' ? t.substr(0, t.length - 1) : t;
 };

--- a/spec/helpers/tmpdir.js
+++ b/spec/helpers/tmpdir.js
@@ -1,0 +1,6 @@
+/*global require */
+var os = require('os')
+module.exports.normalize = function() {
+	var t = os.tmpdir();
+	return t.substr(-1) === '/' ? t.substr(0, t.length - 1) : t;
+};

--- a/spec/tmppath-spec.js
+++ b/spec/tmppath-spec.js
@@ -2,17 +2,18 @@
 var underTest = require ('../src/util/tmppath'),
 	path = require('path'),
 	os = require('os'),
+	tmpdir = require('./helpers/tmpdir.js'),
 	fs = require('fs');
 describe('tmppath', function () {
 	'use strict';
 	it('returns an uuid v4 subpath of tmpdir without any arguments', function () {
 		var result = underTest();
-		expect(path.dirname(result)).toEqual(os.tmpdir());
+		expect(path.dirname(result)).toEqual(tmpdir.normalize());
 		expect(/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/.test(path.basename(result))).toBeTruthy();
 	});
 	it('appends the extension if provided as an argument', function () {
 		var result = underTest('.txt');
-		expect(path.dirname(result)).toEqual(os.tmpdir());
+		expect(path.dirname(result)).toEqual(tmpdir.normalize());
 		expect(/^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}\.txt$/.test(path.basename(result))).toBeTruthy();
 	});
 	it('uses the provided string generator if supplied', function () {
@@ -21,7 +22,7 @@ describe('tmppath', function () {
 			},
 			result = underTest('.txt', generator);
 
-		expect(path.dirname(result)).toEqual(os.tmpdir());
+		expect(path.dirname(result)).toEqual(tmpdir.normalize());
 		expect(path.basename(result)).toEqual('generated.txt');
 	});
 	it('keeps generating until if it generates an existing file path', function () {

--- a/spec/zipdir-spec.js
+++ b/spec/zipdir-spec.js
@@ -4,6 +4,7 @@ var tmppath = require('../src/util/tmppath'),
 	fs = require('fs'),
 	path = require('path'),
 	os = require('os'),
+	tmpdir = require('./helpers/tmpdir.js'),
 	underTest = require('../src/tasks/zipdir');
 describe('zipdir', function () {
 	'use strict';
@@ -53,7 +54,7 @@ describe('zipdir', function () {
 				done.fail('invalid archive');
 			}
 
-			expect(path.dirname(argpath)).toEqual(os.tmpdir());
+			expect(path.dirname(argpath)).toEqual(tmpdir.normalize());
 			expect(fs.readFileSync(path.join(unpacked, 'root.txt'), 'utf8')).toEqual('text1');
 			expect(fs.readFileSync(path.join(unpacked, 'subdir', 'sub.txt'), 'utf8')).toEqual('text2');
 

--- a/spec/zipdir-spec.js
+++ b/spec/zipdir-spec.js
@@ -3,7 +3,6 @@ var tmppath = require('../src/util/tmppath'),
 	shell = require('shelljs'),
 	fs = require('fs'),
 	path = require('path'),
-	os = require('os'),
 	tmpdir = require('./helpers/tmpdir.js'),
 	underTest = require('../src/tasks/zipdir');
 describe('zipdir', function () {


### PR DESCRIPTION
In order to remedy the "trailing slash" problem in OSX. 

Today all tests with `os.tmpdir()` fails with 
`Expected '/var/folders/tg/b2nt4t8s7ys8v3ft9gytls840000gn/T' to equal '/var/folders/tg/b2nt4t8s7ys8v3ft9gytls840000gn/T/'`

This fix handles this problem, and should not cause problem on Windows 