### PR TITLE
Add a description field to the created Lambda base on package.json's description

### DIFF
--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -308,6 +308,20 @@ describe('create', function () {
 				expect(lambdaResult.Runtime).toEqual('nodejs4.3');
 			}).then(done, done.fail);
 		});
+		it('uses the package.json description field in the created lambda Description', function (done) {
+			config.name = undefined;
+			createFromDir('package-description').then(function (creationResult) {
+				expect(creationResult.lambda).toEqual({
+					role: 'package-description-executor',
+					region: awsRegion,
+					name: 'package-description'
+				});
+			}).then(function () {
+				return lambda.getFunctionConfigurationPromise({FunctionName: 'package-description'});
+			}).then(function (lambdaResult) {
+				expect(lambdaResult.Description).toEqual('This is the package description');
+			}).then(done, done.fail);
+		});
 
 		it('saves the configuration into claudia.json', function (done) {
 			createFromDir('hello-world').then(function (creationResult) {

--- a/spec/test-projects/package-description/main.js
+++ b/spec/test-projects/package-description/main.js
@@ -1,0 +1,6 @@
+/*global exports, console*/
+exports.handler = function (event, context) {
+	'use strict';
+	console.log(event);
+	context.succeed('hello world');
+};

--- a/spec/test-projects/package-description/package.json
+++ b/spec/test-projects/package-description/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "package-description",
+  "description": "This is the package description",
+  "private": true,
+  "files": ["main.js"]
+}

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -58,22 +58,24 @@ module.exports = function create(options) {
 				return 'no files match additional policies (' + options.policies + ')';
 			}
 		},
-		getPackageName = function () {
-			if (options.name) {
-				return Promise.resolve(options.name);
-			}
+		getPackageNameAndDesciption = function () {
 			return readjson(path.join(source, 'package.json')).then(function (jsonConfig) {
-				var name = jsonConfig.name && jsonConfig.name.trim();
+				var name = options.name || (jsonConfig.name && jsonConfig.name.trim()),
+				    description = jsonConfig.description && jsonConfig.description.trim();
 				if (!name) {
 					return Promise.reject('project name is missing. please specify with --name or in package.json');
 				}
-				return name;
+				return {
+					name: name,
+					description: description
+				};
 			});
 		},
-		createLambda = function (functionName, zipFile, roleArn, retriesLeft) {
+		createLambda = function (functionName, functionDesc, zipFile, roleArn, retriesLeft) {
 			var functionMeta = {
 				Code: { ZipFile: zipFile },
 				FunctionName: functionName,
+				Description: functionDesc,
 				Handler: options.handler || (options['api-module'] + '.router'),
 				Role: roleArn,
 				Runtime: options.runtime || 'nodejs4.3',
@@ -87,7 +89,7 @@ module.exports = function create(options) {
 			return lambda.createFunctionPromise(functionMeta).catch(function (error) {
 				if (error && error.cause && error.cause.message == iamPropagationError) {
 					return Promise.delay(3000).then(function () {
-						return createLambda(functionName, zipFile, roleArn, retriesLeft - 1);
+						return createLambda(functionName, functionDesc, zipFile, roleArn, retriesLeft - 1);
 					});
 				} else {
 					return Promise.reject(error);
@@ -177,12 +179,14 @@ module.exports = function create(options) {
 			});
 		},
 		packageArchive,
+		functionDesc,
 		functionName;
 	if (validationError()) {
 		return Promise.reject(validationError());
 	}
-	return getPackageName().then(function (name) {
-		functionName = name;
+	return getPackageNameAndDesciption().then(function (nameAndDesc) {
+		functionName = nameAndDesc.name;
+		functionDesc = nameAndDesc.description;
 	}).then(function () {
 		return collectFiles(source);
 	}).then(function (dir) {
@@ -202,7 +206,7 @@ module.exports = function create(options) {
 	}).then(function () {
 		return fs.readFileAsync(packageArchive);
 	}).then(function (fileContents) {
-		return createLambda(functionName, fileContents, roleMetadata.Role.Arn, 10);
+		return createLambda(functionName, functionDesc, fileContents, roleMetadata.Role.Arn, 10);
 	})
 	.then(function (lambdaMetadata) {
 		if (options['api-module']) {


### PR DESCRIPTION
Claudia CLI is awesome, but there are times we need to go to AWS Lambda web console. It'll be great to see a description text of the created Lambda function there, instead of just the function name which may not be very descriptive. 

This PR uses the optional "description" field at package.json as the Lambda function description during _claudia create_.

Sample end result:
<img width="983" alt="pr-claudia-lambda-description" src="https://cloud.githubusercontent.com/assets/2024333/14759447/8dc92ba0-08d8-11e6-92bd-1e1219cf278b.png">
