### PR TITLE
Add --memory and --timeout options

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
 	"preset":"crockford",
 	"validateIndentation": "\t",
-	"requireBlocksOnNewline": 0
+	"requireBlocksOnNewline": 0,
+	"excludeFiles": ["spec/**/node_modules/"]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+spec/**/node_modules/

--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -284,6 +284,76 @@ describe('create', function () {
 			}).then(done, done.fail);
 		});
 	});
+	describe('memory option support', function () {
+		it('fails if memory value is < 128', function (done) {
+			config.memory = 128 - 64;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the memory value provided must be greater than or equal to 128');
+			}).then(done, done.fail);
+		});
+		it('fails if memory value is 0', function (done) {
+			config.memory = 0;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the memory value provided must be greater than or equal to 128');
+			}).then(done, done.fail);
+		});
+		it('fails if memory value is > 1536', function (done) {
+			config.memory = 1536 + 64;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the memory value provided must be less than or equal to 1536');
+			}).then(done, done.fail);
+		});
+		it('fails if memory value is not a multiple of 64', function (done) {
+			config.memory = 128 + 2;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the memory value provided must be a multiple of 64');
+			}).then(done, done.fail);
+		});
+		it('creates memory size of 128 MB by default', function (done) {
+			createFromDir('hello-world').then(function () {
+				return lambda.getFunctionConfigurationPromise({FunctionName: testRunName});
+			}).then(function (lambdaResult) {
+				expect(lambdaResult.MemorySize).toEqual(128);
+			}).then(done, done.fail);
+		});
+		it('can specify memory size using the --memory argument', function (done) {
+			config.memory = 1536;
+			createFromDir('hello-world').then(function () {
+				return lambda.getFunctionConfigurationPromise({FunctionName: testRunName});
+			}).then(function (lambdaResult) {
+				expect(lambdaResult.MemorySize).toEqual(1536);
+			}).then(done, done.fail);
+		});
+	});
+	describe('timeout option support', function () {
+		it('fails if timeout value is < 1', function (done) {
+			config.timeout = 0;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the timeout value provided must be greater than or equal to 1');
+			}).then(done, done.fail);
+		});
+		it('fails if timeout value is > 300', function (done) {
+			config.timeout = 301;
+			createFromDir('hello-world').then(done.fail, function (error) {
+				expect(error).toEqual('the timeout value provided must be less than or equal to 300');
+			}).then(done, done.fail);
+		});
+		it('creates timeout of 3 seconds by default', function (done) {
+			createFromDir('hello-world').then(function () {
+				return lambda.getFunctionConfigurationPromise({FunctionName: testRunName});
+			}).then(function (lambdaResult) {
+				expect(lambdaResult.Timeout).toEqual(3);
+			}).then(done, done.fail);
+		});
+		it('can specify timeout using the --timeout argument', function (done) {
+			config.timeout = 300;
+			createFromDir('hello-world').then(function () {
+				return lambda.getFunctionConfigurationPromise({FunctionName: testRunName});
+			}).then(function (lambdaResult) {
+				expect(lambdaResult.Timeout).toEqual(300);
+			}).then(done, done.fail);
+		});
+	});
 	describe('creating the function', function () {
 		it('returns an object containing the new claudia configuration', function (done) {
 			createFromDir('hello-world').then(function (creationResult) {

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -57,6 +57,25 @@ module.exports = function create(options) {
 			if (options.policies && !policyFiles().length) {
 				return 'no files match additional policies (' + options.policies + ')';
 			}
+			if (options.memory || options.memory === 0) {
+				if (options.memory < 128) {
+					return 'the memory value provided must be greater than or equal to 128';
+				}
+				if (options.memory > 1536) {
+					return 'the memory value provided must be less than or equal to 1536';
+				}
+				if (options.memory % 64 !== 0) {
+					return 'the memory value provided must be a multiple of 64';
+				}
+			}
+			if (options.timeout || options.timeout === 0) {
+				if (options.timeout < 1) {
+					return 'the timeout value provided must be greater than or equal to 1';
+				}
+				if (options.timeout > 300) {
+					return 'the timeout value provided must be less than or equal to 300';
+				}
+			}
 		},
 		getPackageInfo = function () {
 			return readjson(path.join(source, 'package.json')).then(function (jsonConfig) {
@@ -76,6 +95,8 @@ module.exports = function create(options) {
 				Code: { ZipFile: zipFile },
 				FunctionName: functionName,
 				Description: functionDesc,
+				MemorySize: options.memory,
+				Timeout: options.timeout,
 				Handler: options.handler || (options['api-module'] + '.router'),
 				Role: roleArn,
 				Runtime: options.runtime || 'nodejs4.3',
@@ -290,6 +311,18 @@ module.exports.doc = {
 			optional: true,
 			description: 'Textual description of the lambda function',
 			default: 'the project description from package.json'
+		},
+		{
+			argument: 'memory',
+			optional: true,
+			description: 'The amount of memory, in MB, your Lambda function is given.\nThe value must be a multiple of 64 MB.',
+			default: 128
+		},
+		{
+			argument: 'timeout',
+			optional: true,
+			description: 'The function execution time, in second, at which AWS Lambda should terminate the function',
+			default: 3
 		}
 	]
 };


### PR DESCRIPTION
Add --memory and --timeout options for Lambda MemorySize and Timeout configuration.
Include edge value validations and unit tests.