### PR TITLE
Update RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,7 @@
 
 ### 1.3.1, 25 May 2016
 
-- bugfix for working with non-reentrant dependency modules (eg pg-promise)
+- bugfix for working with non-reentrant dependency modules
 
 ### 1.3.0, 18 May 2016
 


### PR DESCRIPTION
Removing `pg-promise` reference as a non-re-entrant library. There was simply an issue in the library that was immediately fixed.