### PR TITLE
Enable method option invokeWithCredentials

### DIFF
--- a/src/tasks/rebuild-web-api.js
+++ b/src/tasks/rebuild-web-api.js
@@ -122,16 +122,18 @@ module.exports = function rebuildWebApi(functionName, functionVersion, restApiId
 				authorizationType = function () {
 					if (methodOptions && methodOptions.authorizationType && validAuthType(methodOptions.authorizationType.toUpperCase())) {
 						return methodOptions.authorizationType.toUpperCase();
+					} else if (methodOptions && (methodOptions.invokeWithCredentials === true || validCredentials(methodOptions.invokeWithCredentials))) {
+						return 'AWS_IAM';
 					} else {
 						return 'NONE';
 					}
 				},
 				credentials = function () {
-					if (methodOptions) {
-						if (methodOptions.credentials && validCredentials(methodOptions.credentials)) {
-							return methodOptions.credentials;
-						} else if (methodOptions.invokeWithCallerCredentials === true) {
+					if (methodOptions && methodOptions.invokeWithCredentials) {
+						if (methodOptions.invokeWithCredentials === true) {
 							return 'arn:aws:iam::*:user/*';
+						} else if (validCredentials(methodOptions.invokeWithCredentials)) {
+							return methodOptions.invokeWithCredentials;
 						}
 						return null;
 					}

--- a/src/util/valid-credentials.js
+++ b/src/util/valid-credentials.js
@@ -1,0 +1,6 @@
+/*global module */
+module.exports = function validCredentials(type) {
+	'use strict';
+	var credsRegex = /arn:aws:(iam|sts)::(\d{12})?:(.*)/;
+	return credsRegex.test(type);
+};

--- a/src/util/valid-credentials.js
+++ b/src/util/valid-credentials.js
@@ -1,6 +1,6 @@
 /*global module */
-module.exports = function validCredentials(type) {
+module.exports = function validCredentials(creds) {
 	'use strict';
 	var credsRegex = /arn:aws:(iam|sts)::(\d{12})?:(.*)/;
-	return credsRegex.test(type);
+	return (typeof creds === 'string') && credsRegex.test(creds);
 };


### PR DESCRIPTION
See https://github.com/awslabs/aws-apigateway-importer/issues/125

This matches the functionality of the API Gateway console interface:

If invokeWithCallerCredentials option is set to true, API Gateway invokes and executes your target Lambda function using the credentials received by API Gateway in the incoming request.

Requires authorizationType 'AWS_IAM' to be passed along as well. 

```js
api.get('/hello', function (request) {...}, {authorizationType: 'AWS_IAM', invokeWithCallerCredentials: true} );
```

This also allows for arbitrary user credentials in place of caller credentials.

```js
api.get('/hello', function (request) {...}, {authorizationType: 'AWS_IAM', credentials: 'arn:aws:iam::123456789012:user/Somebody'} );
```

If both `invokeWithCallerCredentials` and `credentials` options are passed, `credentials` takes precedence.

Docs not updated with this commit.