### PR TITLE
Removed the check for role for scheduled events.

### DIFF
--- a/spec/add-scheduled-event-spec.js
+++ b/spec/add-scheduled-event-spec.js
@@ -81,12 +81,9 @@ describe('addScheduledEvent', function () {
 			done();
 		});
 	});
-	it('fails when the project config file does not contain the lambda role', function (done) {
+	it('does not fail when the project config file does not contain the lambda role', function (done) {
 		fs.writeFileSync(path.join(workingdir, 'claudia.json'), JSON.stringify({lambda: {name: 'xxx', region: 'abc'}}), 'utf8');
-		underTest(config).then(done.fail, function (reason) {
-			expect(reason).toEqual('invalid configuration -- lambda.role missing from claudia.json');
-			done();
-		});
+		underTest(config).then(done, done.fail);
 	});
 
 

--- a/src/commands/add-scheduled-event.js
+++ b/src/commands/add-scheduled-event.js
@@ -19,7 +19,7 @@ module.exports = function addScheduledEvent(options) {
 			return lambda.getFunctionConfigurationPromise({FunctionName: lambdaConfig.name, Qualifier: options.version});
 		},
 		readConfig = function () {
-			return loadConfig(options, {lambda: {name: true, region: true, role: true}})
+			return loadConfig(options, {lambda: {name: true, region: true, role: false}})
 				.then(function (config) {
 					lambdaConfig = config.lambda;
 				}).then(initServices)


### PR DESCRIPTION
The addScheduledEvent command was checking for the presence of a role in the config but this was not needed. Now the command will work if the role is not in the config file.