### PR TITLE
Populate requestParameters when creating a method

### DIFF
--- a/src/util/param-extractor.js
+++ b/src/util/param-extractor.js
@@ -1,0 +1,14 @@
+/*global module */
+module.exports = function paramExtractor(pathString) {
+	'use strict';
+	var pathComponents = pathString.split('/'),
+		apiParamsRegex = /\{(.*)\}/g, params = [];
+
+	pathComponents.forEach(function (pathComponent) {
+		if (pathComponent.match(apiParamsRegex)) {
+			params.push(apiParamsRegex.exec(pathComponent)[1]);
+		}
+	});
+
+	return params;
+};


### PR DESCRIPTION
This PR ensures request parameters are correctly created in API Gateway. This allows caching to be correctly used and should have no impact if a developer doesn't want to use caching.

Addresses the bug in issue #65.