### PR TITLE
allow setting AWS http client time out with --aws-client-timeout

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -47,6 +47,9 @@ var minimist = require('minimist'),
 		if (args.profile) {
 			AWS.config.credentials = new AWS.SharedIniFileCredentials({profile: args.profile});
 		}
+		if (args['aws-client-timeout']) {
+			AWS.config.httpOptions = { timeout: args['aws-client-timeout'] };
+		}
 		commands[command](args, logger).then(function (result) {
 			if (result) {
 				console.log(JSON.stringify(result, null, 2));

--- a/docs/update.md
+++ b/docs/update.md
@@ -32,3 +32,4 @@ claudia update {OPTIONS}
 *  `--set-env-from-json`:  _optional_ file path to a JSON file containing environment variables to set
   * _For example_: production-env.json
 *  `--env-kms-key-arn`:  _optional_ KMS Key ARN to encrypt/decrypt environment variables
+*  `--aws-client-timeout`: _optional_ The number of milliseconds to wait before connection time out on AWS SDK Client. Defaults to two minutes (120000)


### PR DESCRIPTION
This configuration allows us to change the default AWS http client time out (120,000 ms) avoiding time out error on lamba update over low speed connections when the zip package size is too large.