### PR TITLE
fix: documentation indicates wrong node 6.10 name

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -39,7 +39,7 @@ claudia create {OPTIONS}
   * _For example_: arn:aws:iam::123456789012:role/FileConverter
 *  `--runtime`:  (_optional_) Node.js runtime to use. For supported values, see
   http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html
-  * _Defaults to_: node6.10
+  * _Defaults to_: nodejs6.10
 *  `--description`:  (_optional_) Textual description of the lambda function
   * _Defaults to_: the project description from package.json
 *  `--memory`:  (_optional_) The amount of memory, in MB, your Lambda function is given.


### PR DESCRIPTION
The AWS documentation indicates the following information
Valid Values: nodejs | nodejs4.3 | nodejs6.10 | java8 | python2.7 | dotnetcore1.0 | nodejs4.3-edge
```
The default value for --runtime should be nodejs6.10 not node6.10