### PR TITLE
Rewrite fs.renameAsync to fsUtil.copy in /tasks/collect-files.js

### DIFF
--- a/src/tasks/collect-files.js
+++ b/src/tasks/collect-files.js
@@ -42,7 +42,7 @@ module.exports = function collectFiles(sourcePath, useLocalDependencies, optiona
 			fsUtil.ensureCleanDir(packDir);
 			return runNpm(packDir, 'pack "' + path.resolve(sourcePath) + '"', logger)
 			.then(() => extractTarGz(path.join(packDir, expectedName), packDir))
-			.then(() => fs.renameAsync(path.join(packDir, 'package'), targetDir))
+			.then(() => fsUtil.copy(path.join(packDir, 'package','*'), targetDir))
 			.then(() => {
 				fsUtil.rmDir(packDir);
 				return targetDir;


### PR DESCRIPTION
See issue #110: Claudia Create fails with errno -4048 on Windows 7