### PR TITLE
Fix delete AliasAttribute in UserPool object

### DIFF
--- a/src/commands/add-cognito-user-pool-trigger.js
+++ b/src/commands/add-cognito-user-pool-trigger.js
@@ -47,7 +47,7 @@ module.exports = function addCognitoUserPoolTrigger(options, optionalLogger) {
 				data.UserPoolId = data.Id;
 				data.LambdaConfig = data.LambdaConfig || {};
 				options.events.split(',').forEach(name => data.LambdaConfig[name] = lambdaConfig.arn);
-				['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers'].forEach(n => delete data[n]);
+				['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers','AliasAttributes'].forEach(n => delete data[n]);
 				return cognito.updateUserPool(data).promise();
 			});
 		};


### PR DESCRIPTION
I use "add-cognito-user-pool-trigger", but claudia caused error.
```sh
% claudia add-cognito-user-pool-trigger --events CustomMessage --user-pool-id ap-northeast-1_XXXXXXXX
{ UnexpectedParameter: Unexpected key 'AliasAttributes' found in params
　：
```
It is necessary to delete 'AliasAttributes' in describeUserPool's object in add-cognito-user-pool-trigger.js. This PR implemented it.