### PR TITLE
`fs-promise` util does not modify `fs` standard library

### DIFF
--- a/spec/cognito-authorizer-integration-spec.js
+++ b/spec/cognito-authorizer-integration-spec.js
@@ -6,7 +6,7 @@ const create = require('../src/commands/create'),
 	path = require('path'),
 	tmppath = require('../src/util/tmppath'),
 	callApi = require('../src/util/call-api'),
-	fs = require('../src/util/fs-promise'),
+	fsPromise = require('../src/util/fs-promise'),
 	fsUtil = require('../src/util/fs-util'),
 	awsRegion = require('./util/test-aws-region'),
 	cognitoUserPool = require('./util/cognito-user-pool');
@@ -34,9 +34,9 @@ describe('cognitoAuthorizers', () => {
 			workingdir = tmppath();
 			shell.mkdir(workingdir);
 			shell.cp('-r', 'spec/test-projects/cognito-authorizers/*', workingdir);
-			return fs.readFileAsync(path.join(workingdir, 'api.js'), 'utf-8')
+			return fsPromise.readFileAsync(path.join(workingdir, 'api.js'), 'utf-8')
 				.then(content => content.replace('TEST-USER-POOL-ARN', cognitoUserPool.getArn()))
-				.then(content => fs.writeFileAsync(path.join(workingdir, 'api.js'), content))
+				.then(content => fsPromise.writeFileAsync(path.join(workingdir, 'api.js'), content))
 				.then(() => create({
 					name: testRunName,
 					version: 'original',

--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -6,7 +6,8 @@ const underTest = require('../src/commands/create'),
 	templateFile = require('../src/util/template-file'),
 	ArrayLogger = require('../src/util/array-logger'),
 	shell = require('shelljs'),
-	fs = require('../src/util/fs-promise'),
+	fs = require('fs'),
+	fsPromise = require('../src/util/fs-promise'),
 	retriableWrap = require('../src/util/retriable-wrap'),
 	path = require('path'),
 	os = require('os'),
@@ -203,7 +204,7 @@ describe('create', () => {
 			beforeEach(done => {
 				roleName = `${testRunName}-manual`;
 				logger = new ArrayLogger();
-				fs.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
+				fsPromise.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
 				.then(lambdaRolePolicy => {
 					return iam.createRole({
 						RoleName: roleName,

--- a/spec/custom-authorizer-integration-spec.js
+++ b/spec/custom-authorizer-integration-spec.js
@@ -8,7 +8,7 @@ const create = require('../src/commands/create'),
 	tmppath = require('../src/util/tmppath'),
 	callApi = require('../src/util/call-api'),
 	fsUtil = require('../src/util/fs-util'),
-	fs = require('../src/util/fs-promise'),
+	fsPromise = require('../src/util/fs-promise'),
 	awsRegion = require('./util/test-aws-region');
 describe('customAuthorizers', () => {
 	'use strict';
@@ -33,9 +33,9 @@ describe('customAuthorizers', () => {
 			testRunName = 'test' + Date.now();
 			shell.mkdir(workingdir);
 			shell.cp('-r', 'spec/test-projects/custom-authorizers/*', workingdir);
-			return fs.readFileAsync(path.join(workingdir, 'api.js'), 'utf-8')
+			return fsPromise.readFileAsync(path.join(workingdir, 'api.js'), 'utf-8')
 			.then(content => content.replace('TEST-AUTH-LAMBDA-NAME', `${testRunName}Auth`))
-			.then(content => fs.writeFileAsync(path.join(workingdir, 'api.js'), content))
+			.then(content => fsPromise.writeFileAsync(path.join(workingdir, 'api.js'), content))
 			.then(() => create({
 				name: `${testRunName}Auth`,
 				version: 'original',

--- a/spec/destroy-role-spec.js
+++ b/spec/destroy-role-spec.js
@@ -1,7 +1,7 @@
 /*global describe, it, expect, beforeEach */
 const underTest = require('../src/util/destroy-role'),
 	addPolicy = require('../src/tasks/add-policy'),
-	fs = require('../src/util/fs-promise'),
+	fsPromise = require('../src/util/fs-promise'),
 	aws = require('aws-sdk'),
 	templateFile = require('../src/util/template-file');
 describe('destroyRole', () => {
@@ -11,7 +11,7 @@ describe('destroyRole', () => {
 		testRunName = `test${Date.now()}-executor`;
 		iam = new aws.IAM();
 
-		fs.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
+		fsPromise.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
 		.then(lambdaRolePolicy => {
 			return iam.createRole({
 				RoleName: testRunName,

--- a/spec/fs-promise-spec.js
+++ b/spec/fs-promise-spec.js
@@ -2,7 +2,8 @@
 const shell = require('shelljs'),
 	tmppath = require('../src/util/tmppath'),
 	path = require('path'),
-	fs = require('../src/util/fs-promise');
+	fs = require('fs'),
+	fsPromise = require('../src/util/fs-promise');
 describe('fs-promise', () => {
 	'use strict';
 	let workingdir, testRunName, filePath;
@@ -18,18 +19,18 @@ describe('fs-promise', () => {
 	describe('readFileAsync', () => {
 		it('reads file contents', done => {
 			fs.writeFileSync(filePath, 'fileContents-123', 'utf8');
-			fs.readFileAsync(filePath, 'utf8')
+			fsPromise.readFileAsync(filePath, 'utf8')
 			.then(contents => expect(contents).toEqual('fileContents-123'))
 			.then(done, done.fail);
 		});
 		it('fails if no file', done => {
-			fs.readFileAsync(filePath, 'utf8')
+			fsPromise.readFileAsync(filePath, 'utf8')
 			.then(done.fail, done);
 		});
 	});
 	describe('writeFileAsync', () => {
 		it('writes file contents', done => {
-			fs.writeFileAsync(filePath, 'fileContents-123', 'utf8')
+			fsPromise.writeFileAsync(filePath, 'fileContents-123', 'utf8')
 			.then(() => {
 				const contents = fs.readFileSync(filePath, 'utf8');
 				expect(contents).toEqual('fileContents-123');
@@ -39,8 +40,8 @@ describe('fs-promise', () => {
 	});
 	describe('unlinkAsync', () => {
 		it('removes a file', done => {
-			fs.writeFileAsync(filePath, 'fileContents-123', 'utf8')
-			.then(() => fs.unlinkAsync(filePath))
+			fsPromise.writeFileAsync(filePath, 'fileContents-123', 'utf8')
+			.then(() => fsPromise.unlinkAsync(filePath))
 			.then(() => fs.accessSync(filePath))
 			.then(done.fail, done);
 		});
@@ -48,8 +49,8 @@ describe('fs-promise', () => {
 	describe('renameAsync', () => {
 		it('renames a file', done => {
 			const newPath = path.join(workingdir, 'new-file.txt');
-			fs.writeFileAsync(filePath, 'fileContents-123', 'utf8')
-			.then(() => fs.renameAsync(filePath, newPath))
+			fsPromise.writeFileAsync(filePath, 'fileContents-123', 'utf8')
+			.then(() => fsPromise.renameAsync(filePath, newPath))
 			.then(() => expect(fs.readFileSync(newPath, 'utf8')).toEqual('fileContents-123'))
 			.then(() => fs.accessSync(filePath))
 			.then(done.fail, done);

--- a/spec/localize-dependencies-spec.js
+++ b/spec/localize-dependencies-spec.js
@@ -5,6 +5,7 @@ const os = require('os'),
 	shell = require('shelljs'),
 	readjson = require('../src/util/readjson'),
 	fs = require('fs'),
+	fsPromise = require('../src/util/fs-promise'),
 	localizeDependencies = require('../src/tasks/localize-dependencies');
 describe('localizeDependencies', () => {
 	'use strict';
@@ -38,7 +39,7 @@ describe('localizeDependencies', () => {
 			return readjson(path.join(__dirname, '..', 'package.json'))
 			.then(content => {
 				content[overrideKey] = value;
-				return fs.writeFileAsync(path.join(workdir, 'package.json'), JSON.stringify(content), { encoding: 'utf8' });
+				return fsPromise.writeFileAsync(path.join(workdir, 'package.json'), JSON.stringify(content), { encoding: 'utf8' });
 			});
 		};
 		it(`does not modify remote dependencies in ${depType}`, done => {

--- a/spec/update-spec.js
+++ b/spec/update-spec.js
@@ -6,7 +6,8 @@ const underTest = require('../src/commands/update'),
 	tmppath = require('../src/util/tmppath'),
 	callApi = require('../src/util/call-api'),
 	ArrayLogger = require('../src/util/array-logger'),
-	fs = require('../src/util/fs-promise'),
+	fs = require('fs'),
+	fsPromise = require('../src/util/fs-promise'),
 	path = require('path'),
 	aws = require('aws-sdk'),
 	os = require('os'),
@@ -77,14 +78,14 @@ describe('update', () => {
 			}).then(done, done.fail);
 		});
 		it('fails if the lambda no longer exists', done => {
-			fs.readFileAsync(path.join(workingdir, 'claudia.json'), 'utf8')
+			fsPromise.readFileAsync(path.join(workingdir, 'claudia.json'), 'utf8')
 			.then(JSON.parse)
 			.then(contents => {
 				contents.lambda.name = contents.lambda.name + '-xxx';
 				return contents;
 			}).then(JSON.stringify)
 			.then(contents => {
-				return fs.writeFileAsync(path.join(workingdir, 'claudia.json'), contents, 'utf8');
+				return fsPromise.writeFileAsync(path.join(workingdir, 'claudia.json'), contents, 'utf8');
 			}).then(() => {
 				return underTest({source: workingdir});
 			}).then(done.fail, reason => {
@@ -255,14 +256,14 @@ describe('update', () => {
 			}).then(done, done.fail);
 		});
 		it('fails if the api no longer exists', done => {
-			fs.readFileAsync(path.join(updateddir, 'claudia.json'), 'utf8')
+			fsPromise.readFileAsync(path.join(updateddir, 'claudia.json'), 'utf8')
 			.then(JSON.parse)
 			.then(contents => {
 				contents.api.id = contents.api.id + '-xxx';
 				return contents;
 			}).then(JSON.stringify)
 			.then(contents => {
-				return fs.writeFileAsync(path.join(updateddir, 'claudia.json'), contents, 'utf8');
+				return fsPromise.writeFileAsync(path.join(updateddir, 'claudia.json'), contents, 'utf8');
 			}).then(() => {
 				return underTest({source: updateddir});
 			}).then(done.fail, reason => {

--- a/spec/util/generic-role.js
+++ b/spec/util/generic-role.js
@@ -3,12 +3,12 @@ const aws = require('aws-sdk'),
 	iam = new aws.IAM(),
 	templateFile = require('../../src/util/template-file'),
 	destroyRole = require('../../src/util/destroy-role'),
-	fs = require('../../src/util/fs-promise.js'),
+	fsPromise = require('../../src/util/fs-promise.js'),
 	genericRoleName = 'test-generic-role-' + Date.now();
 
 module.exports.create = function create(name) {
 	'use strict';
-	return fs.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
+	return fsPromise.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
 		.then(lambdaRolePolicy => {
 			return iam.createRole({
 				RoleName: name || genericRoleName,

--- a/src/commands/add-scheduled-event.js
+++ b/src/commands/add-scheduled-event.js
@@ -1,5 +1,5 @@
 const loadConfig = require('../util/loadconfig'),
-	fs = require('../util/fs-promise'),
+	fsPromise = require('../util/fs-promise'),
 	aws = require('aws-sdk');
 
 module.exports = function addScheduledEvent(options) {
@@ -69,7 +69,7 @@ module.exports = function addScheduledEvent(options) {
 	if (!options.schedule) {
 		return Promise.reject('event schedule not specified. please provide it with --schedule');
 	}
-	return fs.readFileAsync(options.event, 'utf8')
+	return fsPromise.readFileAsync(options.event, 'utf8')
 		.then(contents => {
 			eventData = contents;
 		})

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -15,7 +15,8 @@ const path = require('path'),
 	apiGWUrl = require('../util/apigw-url'),
 	lambdaNameSanitize = require('../util/lambda-name-sanitize'),
 	retry = require('oh-no-i-insist'),
-	fs = require('../util/fs-promise'),
+	fs = require('fs'),
+	fsPromise = require('../util/fs-promise'),
 	os = require('os'),
 	sequentialPromiseMap = require('../util/sequential-promise-map'),
 	lambdaCode = require('../tasks/lambda-code'),
@@ -258,7 +259,7 @@ module.exports = function create(options, optionalLogger) {
 			if (lambdaMetaData.api) {
 				config.api =  { id: lambdaMetaData.api.id, module: lambdaMetaData.api.module };
 			}
-			return fs.writeFileAsync(
+			return fsPromise.writeFileAsync(
 				configFile,
 				JSON.stringify(config, null, 2),
 				'utf8'
@@ -297,7 +298,7 @@ module.exports = function create(options, optionalLogger) {
 				}
 				return iam.getRole({RoleName: options.role}).promise();
 			} else {
-				return fs.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
+				return fsPromise.readFileAsync(templateFile('lambda-exector-policy.json'), 'utf8')
 					.then(lambdaRolePolicy => {
 						return iam.createRole({
 							RoleName: functionName + '-executor',

--- a/src/commands/generate-serverless-express-proxy.js
+++ b/src/commands/generate-serverless-express-proxy.js
@@ -1,5 +1,5 @@
 const path = require('path'),
-	fs = require('../util/fs-promise'),
+	fsPromise = require('../util/fs-promise'),
 	fsUtil = require('../util/fs-util'),
 	NullLogger = require('../util/null-logger'),
 	runNpm = require('../util/run-npm');
@@ -36,7 +36,7 @@ module.exports = function generateServerlessExpressProxy(options, optionalLogger
 			'const server = awsServerlessExpress.createServer(app)',
 			'exports.handler = (event, context) => awsServerlessExpress.proxy(server, event, context)'].join('\n');
 
-		return fs.writeFileAsync(proxyModulePath, contents, 'utf8');
+		return fsPromise.writeFileAsync(proxyModulePath, contents, 'utf8');
 	})
 	.then(() => ({
 		'lambda-handler': proxyModuleName + '.handler'

--- a/src/commands/test-lambda.js
+++ b/src/commands/test-lambda.js
@@ -1,6 +1,6 @@
 const aws = require('aws-sdk'),
 	loadConfig = require('../util/loadconfig'),
-	fs = require('../util/fs-promise');
+	fsPromise = require('../util/fs-promise');
 module.exports = function testLambda(options) {
 	'use strict';
 	let lambdaConfig;
@@ -8,7 +8,7 @@ module.exports = function testLambda(options) {
 		if (!options.event) {
 			return Promise.resolve('');
 		} else {
-			return fs.readFileAsync(options.event, 'utf-8');
+			return fsPromise.readFileAsync(options.event, 'utf-8');
 		}
 	};
 

--- a/src/tasks/add-policy.js
+++ b/src/tasks/add-policy.js
@@ -1,11 +1,11 @@
 const path = require('path'),
-	fs = require('../util/fs-promise'),
+	fsPromise = require('../util/fs-promise'),
 	aws = require('aws-sdk');
 module.exports = function addPolicy(policyName, roleName, fileName) {
 	'use strict';
 	const iam = new aws.IAM();
 	fileName = fileName || path.join(__dirname, '..', '..', 'json-templates', policyName + '.json');
-	return fs.readFileAsync(fileName, 'utf8')
+	return fsPromise.readFileAsync(fileName, 'utf8')
 		.then(policyContents => iam.putRolePolicy({
 			RoleName: roleName,
 			PolicyName: policyName,

--- a/src/tasks/collect-files.js
+++ b/src/tasks/collect-files.js
@@ -2,7 +2,8 @@ const tmppath = require('../util/tmppath'),
 	readjson = require('../util/readjson'),
 	runNpm = require('../util/run-npm'),
 	fsUtil = require('../util/fs-util'),
-	fs = require('../util/fs-promise'),
+	fs = require('fs'),
+	fsPromise = require('../util/fs-promise'),
 	path = require('path'),
 	localizeDependencies = require('./localize-dependencies'),
 	expectedArchiveName = require('../util/expected-archive-name'),
@@ -42,7 +43,7 @@ module.exports = function collectFiles(sourcePath, useLocalDependencies, optiona
 			fsUtil.ensureCleanDir(packDir);
 			return runNpm(packDir, 'pack "' + path.resolve(sourcePath) + '"', logger)
 			.then(() => extractTarGz(path.join(packDir, expectedName), packDir))
-			.then(() => fs.renameAsync(path.join(packDir, 'package'), targetDir))
+			.then(() => fsPromise.renameAsync(path.join(packDir, 'package'), targetDir))
 			.then(() => {
 				fsUtil.rmDir(packDir);
 				return targetDir;

--- a/src/tasks/lambda-code.js
+++ b/src/tasks/lambda-code.js
@@ -1,10 +1,11 @@
 const	path = require('path'),
-	fs = require('../util/fs-promise'),
+	fs = require('fs'),
+	fsPromise = require('../util/fs-promise'),
 	loggingWrap = require('../util/logging-wrap'),
 	aws = require('aws-sdk'),
 	readFromDisk = function (packageArchive) {
 		'use strict';
-		return fs.readFileAsync(packageArchive)
+		return fsPromise.readFileAsync(packageArchive)
 		.then(fileContents => ({ ZipFile: fileContents }));
 	},
 	uploadToS3 = function (filePath, bucket, logger) {

--- a/src/tasks/localize-dependencies.js
+++ b/src/tasks/localize-dependencies.js
@@ -1,4 +1,4 @@
-const fs = require('../util/fs-promise'),
+const fsPromise = require('../util/fs-promise'),
 	path = require('path'),
 	fsUtil = require('../util/fs-util'),
 	readjson = require('../util/readjson');
@@ -25,7 +25,7 @@ module.exports = function (workdir, referencedir) {
 		['dependencies', 'devDependencies', 'optionalDependencies'].forEach(depType => localize(content[depType]));
 		return content;
 	})
-	.then(content => fs.writeFileAsync(packagePath, JSON.stringify(content), {encoding: 'utf8'}))
+	.then(content => fsPromise.writeFileAsync(packagePath, JSON.stringify(content), {encoding: 'utf8'}))
 	.then(() => {
 		const npmRcPath = path.join(referencedir, '.npmrc');
 		if (fsUtil.fileExists(npmRcPath)) {

--- a/src/util/fs-promise.js
+++ b/src/util/fs-promise.js
@@ -1,7 +1,7 @@
 const fs = require('fs'),
 	promisify = function (target, methodName) {
 		'use strict';
-		target[methodName + 'Async'] = function () {
+		return function () {
 			const originalArgs = Array.prototype.slice.call(arguments);
 			return new Promise((resolve, reject) => {
 				const cb = function (err, data) {
@@ -17,9 +17,9 @@ const fs = require('fs'),
 		};
 	};
 
-promisify(fs, 'writeFile');
-promisify(fs, 'readFile');
-promisify(fs, 'unlink');
-promisify(fs, 'rename');
-
-module.exports = fs;
+module.exports = {
+	writeFileAsync: promisify(fs, 'writeFile'),
+	readFileAsync: promisify(fs, 'readFile'),
+	unlinkAsync: promisify(fs, 'unlink'),
+	renameAsync: promisify(fs, 'rename')
+};

--- a/src/util/readjson.js
+++ b/src/util/readjson.js
@@ -1,4 +1,4 @@
-const fs = require('./fs-promise'),
+const fsPromise = require('./fs-promise'),
 	fsUtil = require('./fs-util');
 module.exports = function readJSON(fileName) {
 	'use strict';
@@ -8,7 +8,7 @@ module.exports = function readJSON(fileName) {
 	if (!fsUtil.fileExists(fileName)) {
 		return Promise.reject(fileName + ' is missing');
 	}
-	return fs.readFileAsync(fileName, {encoding: 'utf8'})
+	return fsPromise.readFileAsync(fileName, {encoding: 'utf8'})
 	.then(content => {
 		try {
 			return JSON.parse(content);

--- a/src/util/run-npm.js
+++ b/src/util/run-npm.js
@@ -1,7 +1,7 @@
 const removeKeysWithPrefix = require('./remove-keys-with-prefix'),
 	execPromise = require('./exec-promise'),
 	fsUtil = require('./fs-util'),
-	fs = require('./fs-promise'),
+	fsPromise = require('./fs-promise'),
 	tmppath = require('./tmppath');
 module.exports = function runNpm(dir, options, logger) {
 	'use strict';
@@ -15,7 +15,7 @@ module.exports = function runNpm(dir, options, logger) {
 		env = removeKeysWithPrefix(process.env, 'npm_');
 	}
 	return execPromise(command + ' > ' + npmlog + ' 2>&1', {env: env})
-	.then(() => fs.unlinkAsync(npmlog))
+	.then(() => fsPromise.unlinkAsync(npmlog))
 	.then(() => {
 		process.chdir(cwd);
 		return dir;


### PR DESCRIPTION
`fs-promise` was altering `fs` by adding `-Async` methods. In result
it was impossible to deploy with Claudia any project which uses
`Promise.promisifyAll(fs)` (or if any of its dependency does so)
because that operation want to add `-Async` too.

In this commit `fs-promise` no longer alters `fs` and, instead,
returns just a couple of "asynced" methods.