### PR TITLE
fix test failure on windows

### DIFF
--- a/spec/localize-dependencies-spec.js
+++ b/spec/localize-dependencies-spec.js
@@ -31,7 +31,7 @@ describe('localizeDependencies', () => {
 	});
 	it('complains if the working directory does not contain package.json', done => {
 		localizeDependencies(workdir, referencedir)
-		.then(done.fail, err => expect(err).toEqual(workdir + '/package.json is missing'))
+		.then(done.fail, err => expect(err).toEqual(path.join(workdir, 'package.json') + ' is missing'))
 		.then(done);
 	});
 	['dependencies', 'devDependencies', 'optionalDependencies'].forEach(depType => {


### PR DESCRIPTION
`err` returns a message with a path that uses all native directory separators. Assuming the usage of `/package.json` in the test case causes the string comparison to fail on Windows machines where `workdir` uses back slashes.