### PR TITLE
Ensure npmignore beats gitignore

### DIFF
--- a/spec/collect-files-spec.js
+++ b/spec/collect-files-spec.js
@@ -219,6 +219,20 @@ describe('collectFiles', () => {
 				.then(done, done.fail);
 			});
 		});
+		it(`ignores using .npmignore over .gitignore`, done => {
+			fs.writeFileSync(path.join(sourcedir, '.gitignore'), 'root.txt\nsubdir', 'utf8');
+			// empty npmignore, it should include everything
+			fs.writeFileSync(path.join(sourcedir, '.npmignore'), '', 'utf8');
+			configurePackage({});
+			underTest(sourcedir)
+			.then(packagePath => {
+				destdir = packagePath;
+				expect(shell.test('-e', path.join(packagePath, 'root.txt'))).toBeTruthy();
+				expect(shell.test('-e', path.join(packagePath, 'subdir'))).toBeTruthy();
+			})
+			.then(done, done.fail);
+		});
+
 	});
 	describe('collecting dependencies', () => {
 		beforeEach(() => {


### PR DESCRIPTION
No behavior changed, just adding a test that the contents of `.npmignore` override the contents of `.gitignore` (a file ignored in git ignore should still be included if an npmignore is present and the file is not listed there)

```
> claudia@2.14.2 test /Users/gnarf/Projects/claudia
> node spec/support/jasmine-runner.js "ci" "filter=.npmignore over .gitignore"

Spec started

  1 collectFiles

    1.1 when the files property is not specified
      [pass] ignores using .npmignore over .gitignore (1 sec)

Executed 1 of 622 specs SUCCESS (621 SKIPPED) in 2 secs.