### PR TITLE
Add env var replacement functionality to env.json file.

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -73,6 +73,6 @@ claudia create {OPTIONS}
     * _For example_: subnet-1234abcd,subnet-abcd4567
 *  `--set-env`:  (_optional_) comma-separated list of VAR=VALUE environment variables to set
     * _For example_: S3BUCKET=testbucket,SNSQUEUE=testqueue
-*  `--set-env-from-json`:  (_optional_) file path to a JSON file containing environment variables to set
+*  `--set-env-from-json`:  (_optional_) file path to a JSON file containing environment variables to set.  Variable values can reference environment variables via ${env.} syntax (e.g. "DB_PSWD"="${env.DB_PSWD}" ).
     * _For example_: production-env.json
 *  `--env-kms-key-arn`:  (_optional_) KMS Key ARN to encrypt/decrypt environment variables

--- a/docs/update.md
+++ b/docs/update.md
@@ -29,6 +29,6 @@ claudia update {OPTIONS}
     * _For example_: claudia-uploads
 *  `--set-env`:  (_optional_) comma-separated list of VAR=VALUE environment variables to set
     * _For example_: S3BUCKET=testbucket,SNSQUEUE=testqueue
-*  `--set-env-from-json`:  (_optional_) file path to a JSON file containing environment variables to set
+*  `--set-env-from-json`:  (_optional_) file path to a JSON file containing environment variables to set.  Variable values can reference environment variables via ${env.} syntax (e.g. "DB_PSWD"="${env.DB_PSWD}" ).
     * _For example_: production-env.json
 *  `--env-kms-key-arn`:  (_optional_) KMS Key ARN to encrypt/decrypt environment variables

--- a/spec/read-env-vars-from-options-spec.js
+++ b/spec/read-env-vars-from-options-spec.js
@@ -60,6 +60,22 @@ describe('readEnvVarsFromOptions', () => {
 		});
 	});
 
+	it('converts a valid JSON file containing environment vars into variables from set-env-from-json', () => {
+		const envpath = tmppath();
+		process.env.ENV_TEST_PATH = '/path/to/test';
+		fs.writeFileSync(envpath, JSON.stringify({ 'XPATH': '${env.ENV_TEST_PATH}', 'YPATH': '/var/lib' }), 'utf8');
+		expect(readEnvVarsFromOptions({ 'set-env-from-json': envpath })).toEqual({
+			'XPATH': '/path/to/test',
+			'YPATH': '/var/lib'
+		});
+	});
+	it('throws an error when set-env-from-json is set but the file containes a reference to an invalid env.var', () => {
+		const envpath = tmppath();
+		fs.writeFileSync(envpath, JSON.stringify({ 'XPATH': '${env.ENV_MISSING}', 'YPATH': '/var/lib' }), 'utf8');
+		expect(() => {
+			readEnvVarsFromOptions({ 'set-env-from-json': envpath });
+		}).toThrowError(/Couldn't find expected env var/);
+	});
 	it('throws an error when update-env-from-json is set but the file does not exist', () => {
 		expect(() => {
 			readEnvVarsFromOptions({
@@ -94,5 +110,21 @@ describe('readEnvVarsFromOptions', () => {
 			'XPATH': '/var/www',
 			'YPATH': '/var/lib'
 		});
+	});
+	it('converts a valid JSON file containing environment vars into variables from update-env-from-json', () => {
+		const envpath = tmppath();
+		process.env.ENV_TEST_PATH = '/path/to/test';
+		fs.writeFileSync(envpath, JSON.stringify({ 'XPATH': '${env.ENV_TEST_PATH}', 'YPATH': '/var/lib' }), 'utf8');
+		expect(readEnvVarsFromOptions({ 'update-env-from-json': envpath })).toEqual({
+			'XPATH': '/path/to/test',
+			'YPATH': '/var/lib'
+		});
+	});
+	it('throws an error when update-env-from-json is set but the file containes a reference to an invalid env.var', () => {
+		const envpath = tmppath();
+		fs.writeFileSync(envpath, JSON.stringify({ 'XPATH': '${env.ENV_MISSING}', 'YPATH': '/var/lib' }), 'utf8');
+		expect(() => {
+			readEnvVarsFromOptions({ 'update-env-from-json': envpath });
+		}).toThrowError(/Couldn't find expected env var/);
 	});
 });


### PR DESCRIPTION
I'd like to suggest a new feature be added to the --set-env-from-json functionality. I'd like to be able to provide values from local environment variables. e.g. "DB_PSWD"="${env.DB_PSWD}". This way I don't have passwords in my env.json file that is checked into github.  I would like the ability to check in the env.json file as I have a fair amount of params to pass into my lambda and it simplifies the setup between my project developers. I did look at using the --set-env for just the PSWD values but that threw the exception "Incompatible arguments: cannot specify more than one environment option". Also, the number of env parameters is enough to make the package.json script line extremely long and hence what I believed the value of the --set-env-from-json provided. Additionally, this proposed functionality is giving the --set-env-from-json function the same behaviors as --set-env since I can write --set-env DB_PSWD=${DB_PSWD} in the package.json. I understand that some folks would keep these files local and out of git but in a large dev shop I'd just have to find somewhere else to store and share these files and still passwords would potentially be visible to folks where they should not be.  I'd likely have some process that pulls these passwords from a secure encrypted vault that would be external to this tool but through this enhancement I could get access to these sensitive variables should I choose to do so via environment vars.
I hope you will consider this simple change as I know I have found it useful and would love for it to be in the product so as not have to run off of a fork.