### PR TITLE
adding region to the generate command

### DIFF
--- a/app-templates/package.json
+++ b/app-templates/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "create": "claudia create --region us-east-1 --api-module index",
+    "create": "claudia create --region #{region} --api-module index",
     "deploy": "claudia update"
   },
   "keywords": [],

--- a/spec/generate-spec.js
+++ b/spec/generate-spec.js
@@ -14,12 +14,19 @@ describe('generate', () => {
 		shell.mkdir(workingdir);
 		testRunName = 'test' + Date.now();
 		newObjects = { workingdir: workingdir };
-		config = { name: testRunName, source: workingdir, _: ['generate', 'api'] };
+		config = { name: testRunName, source: workingdir, _: ['generate', 'api'], region: 'us-east-1' };
 	});
 	afterEach(done => {
 		destroyObjects(newObjects).then(done, done.fail);
 	});
 	describe('config validation', () => {
+
+		it('fails if the region is not provided', done => {
+			config.region = '';
+			underTest(config)
+				.then(done.fail, message => expect(message).toEqual('AWS region is missing. please specify with --region.'))
+				.then(done);
+		});
 
 		it('fails if the generate template target is not provided', done => {
 			config._ = ['generate'];

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -10,7 +10,7 @@ module.exports = function generate(args) {
 		source = (args && args.source) || process.cwd(),
 		validationError = function () {
 			if (!args.region) {
-				return 'AWS region is missing. please specify with --region';
+				return 'AWS region is missing. please specify with --region.';
 			}
 
 			if (!commandTarget) {
@@ -39,7 +39,7 @@ module.exports = function generate(args) {
 				}
 				return generatePackage(projectPath, args.region);
 			}).then(() => {
-				console.log('Generating boring overhead successful');
+				console.log('Generating template successful');
 				return;
 			});
 		};
@@ -51,7 +51,7 @@ module.exports = function generate(args) {
 };
 
 module.exports.doc = {
-	description: 'Create a lambda project template that you can immediatelly deploy',
+	description: 'Create a lambda project template that you can immediately deploy',
 	priority: 21,
 	args: [
 		{

--- a/src/util/fs-util.js
+++ b/src/util/fs-util.js
@@ -29,6 +29,11 @@ exports.recursiveList = function (dirPath) {
 	'use strict';
 	return shell.ls('-R', dirPath);
 };
+exports.replaceStringInFile = function (searchPattern, replacePattern, filePath) {
+	'use strict';
+	shell.sed('-i', searchPattern, replacePattern, filePath);
+	return Promise.resolve();
+};
 exports.copyFile = function (fromFile, toFile) {
 	'use strict';
 	const readStream = fs.createReadStream(fromFile);


### PR DESCRIPTION
- added `--region` to`claudia generate`, to specify the region from start.
The generate now sets the proper region to the npm command `create`.
- added `--region` specs
- modified the command docs