### PR TITLE
Added option to support S3 bucket with Server Side Encryption enabled

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -58,6 +58,8 @@ claudia create {OPTIONS}
     You can use this to upload large functions over slower connections more reliably, and to leave a binary artifact
     after uploads for auditing purposes. If not set, the archive will be uploaded directly to Lambda
     * _For example_: claudia-uploads
+*  `--s3-sse`:  (_optional_) The type of Server Side Encryption applied to the S3 bucket referenced in `--use-s3-bucket`.
+    * _For example_: AES256
 *  `--aws-delay`:  (_optional_) number of milliseconds betweeen retrying AWS operations if they fail
     * _For example_: 3000
     * _Defaults to_: 5000

--- a/docs/update.md
+++ b/docs/update.md
@@ -32,6 +32,8 @@ claudia update {OPTIONS}
     You can use this to upload large functions over slower connections more reliably, and to leave a binary artifact
     after uploads for auditing purposes. If not set, the archive will be uploaded directly to Lambda
     * _For example_: claudia-uploads
+*  `--s3-sse`:  (_optional_) The type of Server Side Encryption applied to the S3 bucket referenced in `--use-s3-bucket`.
+    * _For example_: AES256
 *  `--update-env`:  (_optional_) comma-separated list of VAR=VALUE environment variables to set, merging with old variables
     * _For example_: S3BUCKET=testbucket,SNSQUEUE=testqueue
 *  `--set-env`:  (_optional_) comma-separated list of VAR=VALUE environment variables to set. replaces the whole set, removing old variables.

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -392,7 +392,7 @@ module.exports = function create(options, optionalLogger) {
 			}).promise();
 		}
 	})
-	.then(() => lambdaCode(packageArchive, options['use-s3-bucket'], logger))
+	.then(() => lambdaCode(packageArchive, options['use-s3-bucket'], options['s3-sse'], logger))
 	.then(functionCode => {
 		s3Key = functionCode.S3Key;
 		return createLambda(functionName, functionDesc, functionCode, roleMetadata.Role.Arn);
@@ -538,8 +538,14 @@ module.exports.doc = {
 			optional: true,
 			example: 'claudia-uploads',
 			description: 'The name of a S3 bucket that Claudia will use to upload the function code before installing in Lambda.\n' +
-				'You can use this to upload large functions over slower connections more reliably, and to leave a binary artifact\n' +
-				'after uploads for auditing purposes. If not set, the archive will be uploaded directly to Lambda'
+			'You can use this to upload large functions over slower connections more reliably, and to leave a binary artifact\n' +
+			'after uploads for auditing purposes. If not set, the archive will be uploaded directly to Lambda'
+		},
+		{
+			argument: 's3-sse',
+			optional: true,
+			example: 'AES256',
+			description: 'The type of Server Side Encryption applied to the S3 bucket referenced in `--use-s3-bucket`'
 		},
 		{
 			argument: 'aws-delay',

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -201,7 +201,7 @@ module.exports = function update(options, optionalLogger) {
 	})
 	.then(zipFile => {
 		packageArchive = zipFile;
-		return lambdaCode(packageArchive, options['use-s3-bucket'], logger);
+		return lambdaCode(packageArchive, options['use-s3-bucket'], options['s3-sse'], logger);
 	})
 	.then(functionCode => {
 		logger.logStage('updating Lambda');
@@ -293,6 +293,12 @@ module.exports.doc = {
 			description: 'The name of a S3 bucket that Claudia will use to upload the function code before installing in Lambda.\n' +
 				'You can use this to upload large functions over slower connections more reliably, and to leave a binary artifact\n' +
 				'after uploads for auditing purposes. If not set, the archive will be uploaded directly to Lambda'
+		},
+		{
+			argument: 's3-sse',
+			optional: true,
+			example: 'AES256',
+			description: 'The type of Server Side Encryption applied to the S3 bucket referenced in `--use-s3-bucket`'
 		},
 		{
 			argument: 'update-env',

--- a/src/tasks/lambda-code.js
+++ b/src/tasks/lambda-code.js
@@ -8,26 +8,30 @@ const	path = require('path'),
 		return fsPromise.readFileAsync(packageArchive)
 		.then(fileContents => ({ ZipFile: fileContents }));
 	},
-	uploadToS3 = function (filePath, bucket, logger) {
+	uploadToS3 = function (filePath, bucket, serverSideEncryption, logger) {
 		'use strict';
 		const fileKey = path.basename(filePath),
-			s3 = loggingWrap(new aws.S3({signatureVersion: 'v4'}), {log: logger.logApiCall, logName: 's3'});
-		return s3.upload({
-			Bucket: bucket,
-			Key: fileKey,
-			Body: fs.createReadStream(filePath),
-			ACL: 'private'
-		}).promise()
+			s3 = loggingWrap(new aws.S3({signatureVersion: 'v4'}), {log: logger.logApiCall, logName: 's3'}),
+			params = {
+				Bucket: bucket,
+				Key: fileKey,
+				Body: fs.createReadStream(filePath),
+				ACL: 'private'
+			};
+		if (serverSideEncryption) {
+			params.ServerSideEncryption = serverSideEncryption;
+		}
+		return s3.upload(params).promise()
 		.then(() => ({
 			S3Bucket: bucket,
 			S3Key: fileKey
 		}));
 	};
-module.exports = function lambdaCode(zipArchive, s3Bucket, logger) {
+module.exports = function lambdaCode(zipArchive, s3Bucket, s3ServerSideEncryption, logger) {
 	'use strict';
 	if (!s3Bucket) {
 		return readFromDisk(zipArchive);
 	} else {
-		return uploadToS3(zipArchive, s3Bucket, logger);
+		return uploadToS3(zipArchive, s3Bucket, s3ServerSideEncryption, logger);
 	}
 };


### PR DESCRIPTION
Example usage:
claudia update --use-s3-bucket foo --s3-sse AES256

This resolves the "Access Denied" error that currently happens when trying to upload the Lambda function ZIP to an S3 bucket which has Server Side Encryption enabled.