### PR TITLE
Add Node.js 8.10 as supported version in docs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -86,7 +86,7 @@ TEST_TIMEOUT=300000
 
 Here are same house rules for Claudia development. Breaking one of these doesn't necessarily mean that your pull request will not be merged, but following the rules will make it easier and faster to do that. If you decide to break one of these, please explain in the pull request why, so we can revise the rules or adjust the code together.
 
-* AWS Lambda currently supports only Node.js 6.10 and 4.3.2, so we use that one as the baseline for Claudia development. You can use [nvm](https://github.com/creationix/nvm) to manage multiple versions of Node on your development environment if you need to.
+* AWS Lambda currently supports only Node.js 8.10, 6.10 and 4.3.2, so we use that one as the baseline for Claudia development. You can use [nvm](https://github.com/creationix/nvm) to manage multiple versions of Node on your development environment if you need to.
 * ES6 code is allowed and encouraged, as long as it works on 4.3.2. We don't use babel for transpilation. 
 * We use [Jasmine](https://jasmine.github.io) for tests. 
 * We use `eslint` for linting, with the style guide in [`.eslintrc`](https://github.com/claudiajs/claudia/blob/master/.eslintrc.json)


### PR DESCRIPTION
I update the docs to reflect the fact that AWS has added Node.js 8.10 as a [supported version](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html) since [02 April 2018](https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/). Also, Claudia supports it since [09 April 2018](https://claudiajs.com/news/2018/04/09/claudia-4.html).