### PR TITLE
fix for add-cognito-user-pool-trigger, fails when user pool has custom domain

### DIFF
--- a/src/commands/add-cognito-user-pool-trigger.js
+++ b/src/commands/add-cognito-user-pool-trigger.js
@@ -43,7 +43,7 @@ module.exports = function addCognitoUserPoolTrigger(options, optionalLogger) {
 			/* cognito update requires the full config, not just a patch, but some attributes returned
 			 * from describeUserPool are not accepted back into the configuration, so they have to be removed
 			 */
-			['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers', 'AliasAttributes', 'UsernameAttributes', 'Arn'].forEach(n => delete data[n]);
+			['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers', 'AliasAttributes', 'UsernameAttributes', 'Arn', 'Domain'].forEach(n => delete data[n]);
 			if (Object.keys(data.UserPoolAddOns).length === 0) {
 				delete data.UserPoolAddOns;
 			}


### PR DESCRIPTION
If a user pool has a custom domain, `add-cognito-user-pool-trigger` fails as AWS parameter validation fails because the `Domain` attribute is sent back, but not expected.

It seems like an easy fix: `add-cognito-user-pool-trigger.js`, `cleanUpPoolConfig', add 'Domain' to the array of attributes to remove.

I tried this locally and that seems to work.