### PR TITLE
Update max lambda timeout to 900 seconds

### DIFF
--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -578,10 +578,10 @@ describe('create', () => {
 			.then(done.fail, error => expect(error).toEqual('the timeout value provided must be greater than or equal to 1'))
 			.then(done, done.fail);
 		});
-		it('fails if timeout value is > 300', done => {
-			config.timeout = 301;
+		it('fails if timeout value is > 900', done => {
+			config.timeout = 901;
 			createFromDir('hello-world')
-			.then(done.fail, error => expect(error).toEqual('the timeout value provided must be less than or equal to 300'))
+			.then(done.fail, error => expect(error).toEqual('the timeout value provided must be less than or equal to 900'))
 			.then(done, done.fail);
 		});
 		it('creates timeout of 3 seconds by default', done => {
@@ -591,10 +591,10 @@ describe('create', () => {
 			.then(done, done.fail);
 		});
 		it('can specify timeout using the --timeout argument', done => {
-			config.timeout = 300;
+			config.timeout = 900;
 			createFromDir('hello-world')
 			.then(getLambdaConfiguration)
-			.then(lambdaResult => expect(lambdaResult.Timeout).toEqual(300))
+			.then(lambdaResult => expect(lambdaResult.Timeout).toEqual(900))
 			.then(done, done.fail);
 		});
 	});

--- a/spec/update-spec.js
+++ b/spec/update-spec.js
@@ -622,9 +622,9 @@ describe('update', () => {
 			.then(configuration => expect(configuration.Timeout).toEqual(10))
 			.then(done, done.fail);
 		});
-		it('fails if timeout value is > 300', done => {
-			underTest({source: workingdir, version: 'new', timeout: 301})
-			.then(() => done.fail('update succeeded'), error => expect(error).toEqual('the timeout value provided must be less than or equal to 300'))
+		it('fails if timeout value is > 900', done => {
+			underTest({source: workingdir, version: 'new', timeout: 901})
+			.then(() => done.fail('update succeeded'), error => expect(error).toEqual('the timeout value provided must be less than or equal to 900'))
 			.then(() => getLambdaConfiguration())
 			.then(configuration => expect(configuration.Timeout).toEqual(10))
 			.then(done, done.fail);

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -113,8 +113,8 @@ module.exports = function create(options, optionalLogger) {
 				if (options.timeout < 1) {
 					return 'the timeout value provided must be greater than or equal to 1';
 				}
-				if (options.timeout > 300) {
-					return 'the timeout value provided must be less than or equal to 300';
+				if (options.timeout > 900) {
+					return 'the timeout value provided must be less than or equal to 900';
 				}
 			}
 			if (options['allow-recursion'] && options.role && isRoleArn(options.role)) {

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -131,8 +131,8 @@ module.exports = function update(options, optionalLogger) {
 				if (options.timeout < 1) {
 					return Promise.reject('the timeout value provided must be greater than or equal to 1');
 				}
-				if (options.timeout > 300) {
-					return Promise.reject('the timeout value provided must be less than or equal to 300');
+				if (options.timeout > 900) {
+					return Promise.reject('the timeout value provided must be less than or equal to 900');
 				}
 			}
 			if (options.memory || options.memory === 0) {


### PR DESCRIPTION
AWS has recently increased the timeout limit from 300 seconds (5 minutes) to 900 seconds (15 minutes).

This PR updates all instances of `300` seconds with `900` seconds.

https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/