### PR TITLE
allow to assume role

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "dependencies": {
     "archiver": "^2.0.0",
-    "aws-sdk": "^2.382.0",
+    "aws-sdk": "^2.395.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "gunzip-maybe": "^1.4.0",


### PR DESCRIPTION
From the [sdk](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/TemporaryCredentials.html): `Note: AWS.TemporaryCredentials is deprecated, but remains available for backwards compatibility. AWS.ChainableTemporaryCredentials is the preferred class for temporary credentials.` 

