### PR TITLE
Dedupe with "--production" and "--no-optional" flags

### DIFF
--- a/spec/clean-up-package-spec.js
+++ b/spec/clean-up-package-spec.js
@@ -111,7 +111,7 @@ describe('cleanUpPackage', () => {
 			expect(logger.getCombinedLog()).toEqual([
 				['call', 'removing optional dependencies'],
 				['call', 'npm install -q --no-package-lock --no-audit --production --no-optional --dry-run'],
-				['call', 'npm dedupe -q --no-package-lock --dry-run']
+				['call', 'npm dedupe -q --no-package-lock --production --no-optional --dry-run']
 			]);
 		})
 		.then(done, done.fail);

--- a/src/tasks/clean-up-package.js
+++ b/src/tasks/clean-up-package.js
@@ -6,7 +6,9 @@ module.exports = function cleanUpPackage(packageDir, options, logger) {
 	'use strict';
 	const npmOptions = (options && options['npm-options']) ? options['npm-options'].split(' ') : [],
 		dedupe = function () {
-			return runNpm(packageDir, ['dedupe', '-q', '--no-package-lock'].concat(npmOptions), logger, true);
+			return options['optional-dependencies'] === false
+				? runNpm(packageDir, ['dedupe', '-q', '--no-package-lock', '--production', '--no-optional'].concat(npmOptions), logger, true)
+				: runNpm(packageDir, ['dedupe', '-q', '--no-package-lock'].concat(npmOptions), logger, true);
 		},
 		runPostPackageScript = function () {
 			const script = options['post-package-script'];


### PR DESCRIPTION
Unless these flags are set, dedupe re-installs optional
dependencies.
This issue was confirmed on Node 12, 14, 16 with
NPM versions 6.14.12 and 7.14.0.