### PR TITLE
fix add-cognito-user-pool-trigger extra parameters

### DIFF
--- a/src/commands/add-cognito-user-pool-trigger.js
+++ b/src/commands/add-cognito-user-pool-trigger.js
@@ -43,7 +43,7 @@ module.exports = function addCognitoUserPoolTrigger(options, optionalLogger) {
 			/* cognito update requires the full config, not just a patch, but some attributes returned
 			 * from describeUserPool are not accepted back into the configuration, so they have to be removed
 			 */
-			['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers', 'AliasAttributes', 'UsernameAttributes', 'Arn', 'Domain'].forEach(n => delete data[n]);
+			['Id', 'Name', 'LastModifiedDate', 'CreationDate', 'SchemaAttributes', 'EstimatedNumberOfUsers', 'AliasAttributes', 'UsernameAttributes', 'Arn', 'Domain', 'UsernameConfiguration', 'CustomDomain'].forEach(n => delete data[n]);
 			if (data.AdminCreateUserConfig && data.AdminCreateUserConfig.UnusedAccountValidityDays) {
 				delete data.AdminCreateUserConfig.UnusedAccountValidityDays;
 			}


### PR DESCRIPTION
Hey! as the spec from `updateUserPool` changed, claudia wasnt able to update the user pool, so in order to do that, I modified the `cleanUpPoolConfig` to remove extra parameters.

**Already tested locally and tests completed**

This was the output before:

```
MultipleValidationErrors: There were 2 validation errors:
* UnexpectedParameter: Unexpected key 'CustomDomain' found in params
* UnexpectedParameter: Unexpected key 'UsernameConfiguration' found in params
    at ParamValidator.validate (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:40:28)
    at Request.VALIDATE_PARAMETERS (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:132:42)
    at Request.callListeners (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at callNextListener (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
    at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:86:9
    at finish (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:386:7)
    at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:404:9
    at SharedIniFileCredentials.get (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/credentials.js:127:7)
    at getAsyncCredentials (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:398:24)
    at Config.getCredentials (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:418:9) {
  code: 'MultipleValidationErrors',
  errors: [
    UnexpectedParameter: Unexpected key 'CustomDomain' found in params
        at ParamValidator.fail (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:50:37)
        at ParamValidator.validateStructure (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:77:14)
        at ParamValidator.validateMember (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:88:21)
        at ParamValidator.validate (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:34:10)
        at Request.VALIDATE_PARAMETERS (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:132:42)
        at Request.callListeners (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
        at callNextListener (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
        at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:86:9
        at finish (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:386:7)
        at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:404:9 {
      code: 'UnexpectedParameter',
      time: 2021-12-20T23:46:12.556Z
    },
    UnexpectedParameter: Unexpected key 'UsernameConfiguration' found in params
        at ParamValidator.fail (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:50:37)
        at ParamValidator.validateStructure (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:77:14)
        at ParamValidator.validateMember (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:88:21)
        at ParamValidator.validate (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/param_validator.js:34:10)
        at Request.VALIDATE_PARAMETERS (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:132:42)
        at Request.callListeners (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
        at callNextListener (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
        at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/event_listeners.js:86:9
        at finish (/home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:386:7)
        at /home/damnyorch/.nvm/versions/node/v15.0.1/lib/node_modules/claudia/node_modules/aws-sdk/lib/config.js:404:9 {
      code: 'UnexpectedParameter',
      time: 2021-12-20T23:46:12.556Z
    }
  ],
  time: 2021-12-20T23:46:12.556Z
}

```