### PR TITLE
Add nodejs16, remove nodejs10.x

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release history
 
+### 5.14.2 (15 August 2022)
+
+- add nodejs16.x as supported version
+- remove nodejs12.x as supported version
+
 ### 5.14.1 (17 March 2022)
 
 - additional fixes for the lambda lifecycle updates, thanks to [Mangwan](https://github.com/CodeBanBan)

--- a/contributing.md
+++ b/contributing.md
@@ -98,8 +98,8 @@ TEST_TIMEOUT=300000
 
 Here are same house rules for Claudia development. Breaking one of these doesn't necessarily mean that your pull request will not be merged, but following the rules will make it easier and faster to do that. If you decide to break one of these, please explain in the pull request why, so we can revise the rules or adjust the code together.
 
-* AWS Lambda currently supports only Node.js 10 and 8.10, so we use those ones as the baseline for Claudia development. You can use [nvm](https://github.com/creationix/nvm) to manage multiple versions of Node on your development environment if you need to.
-* ES6 code is allowed and encouraged, as long as it works on Node 8. We don't use babel for transpilation. 
+* AWS Lambda currently supports Node.js versions 16, 14 and 12, so we use those ones as the baseline for Claudia development. You can use [nvm](https://github.com/creationix/nvm) to manage multiple versions of Node on your development environment if you need to.
+* ES6 code is allowed and encouraged, as long as it works on Node 12. We don't use babel for transpilation. 
 * We use [Jasmine](https://jasmine.github.io) for tests. 
 * We use `eslint` for linting, with the style guide in [`.eslintrc`](https://github.com/claudiajs/claudia/blob/master/.eslintrc.json)
   * If a particular line of code needs to relax linting rules, use the `//eslint-disable-line` trick instead of disabling it for the whole file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudia",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Deploy Node.js projects to AWS Lambda and API Gateway easily.",
   "license": "MIT",
   "repository": {

--- a/spec/create-spec.js
+++ b/spec/create-spec.js
@@ -21,7 +21,7 @@ describe('create', () => {
 
 	let workingdir, testRunName, iam, lambda, s3, newObjects, config, logs, apiGatewayPromise, sns;
 	const defaultRuntime = 'nodejs14.x',
-		supportedRuntimes = ['nodejs14.x', 'nodejs12.x', 'nodejs10.x'],
+		supportedRuntimes = ['nodejs16.x', 'nodejs14.x', 'nodejs12.x'],
 		createFromDir = function (dir, logger) {
 			if (!fs.existsSync(workingdir)) {
 				fs.mkdirSync(workingdir);


### PR DESCRIPTION
Just got an email from AWS saying they are starting the process for end of support for Node.js 12.  They are recommending updating to nodejs16, so I though it would be good to update the docs and command line options.  I also noticed that nodejs10 was still a supported runtime, but I think lamdba function would fail now since AWS removed support for it January 1, 2022.